### PR TITLE
🔒 Fix argument injection in tracker3 search

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
@@ -96,7 +96,7 @@ class GioSearchBackend(private val fallback: GioBackend = GioBackend()) : IOBack
 
     private fun runTrackerSearch(query: com.imbric.core.models.VfsQuery): Flow<String> = flow {
         val flag = if (query.contentSearch) "-c" else "-f"
-        val process = ProcessBuilder("tracker3", "search", "--disable-color", flag, query.text)
+        val process = ProcessBuilder("tracker3", "search", "--disable-color", flag, "--", query.text)
             .start()
         
         try {


### PR DESCRIPTION
🎯 **What:** Fixed an argument injection vulnerability where the `tracker3 search` command could mistake user queries for command flags.
⚠️ **Risk:** If a malicious or poorly formatted search query starting with `-` was passed, it could be executed as a command-line flag by the tracker process, potentially altering behavior or causing crashes.
🛡️ **Solution:** Added a double dash (`--`) to the ProcessBuilder arguments directly before the user query string. The `--` standardizes CLI behavior by signaling the end of options, ensuring all following parameters are treated purely as positional arguments (search queries).

---
*PR created automatically by Jules for task [572355499390206377](https://jules.google.com/task/572355499390206377) started by @dragon-Elec*