### PR TITLE
🧪 Add BackendRegistry edge case test

### DIFF
--- a/src/test/kotlin/com/imbric/core/ifs/BackendRegistryTest.kt
+++ b/src/test/kotlin/com/imbric/core/ifs/BackendRegistryTest.kt
@@ -43,4 +43,14 @@ class BackendRegistryTest {
         assert(schemes.contains("memory"))
         assert(schemes.contains("smb"))
     }
+
+    @Test
+    fun testGetIoSmartRoutingCanHandle() {
+        val customBackend = object : InMemoryBackend("custom") {
+            override fun canHandle(uri: String): Boolean = uri.startsWith("magic://")
+        }
+        BackendRegistry.registerIo("custom", customBackend)
+        val backend = BackendRegistry.getIo("magic://foo/bar")
+        assertEquals("custom", backend?.scheme)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing test for `BackendRegistry`'s smart routing logic.
📊 **Coverage:** Now tests the scenario where exact scheme match fails, but a backend is selected because its `canHandle` method returns true for the URI.
✨ **Result:** Improved test coverage and reliability for VFS routing.

---
*PR created automatically by Jules for task [12675424701969677339](https://jules.google.com/task/12675424701969677339) started by @dragon-Elec*