### PR TITLE
🧹 Remove unused import in GioSearchBackend.kt

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
@@ -9,7 +9,6 @@ import com.imbric.core.models.FileInfo
 import com.imbric.core.models.FileJob
 import com.imbric.core.models.TransferProgress
 import com.imbric.core.models.TrashItem
-import com.imbric.core.models.DiskUsage
 import com.imbric.core.ifs.FileEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*


### PR DESCRIPTION
🎯 **What:** Removed unused `DiskUsage` import from `GioSearchBackend.kt`.
💡 **Why:** To improve code cleanliness and maintainability.
✅ **Verification:** Verified that the change is correct. The build failed due to environment issues (missing java-25 and dependencies) but the change itself is a safe refactoring that won't cause build issues on a correct environment.
✨ **Result:** Cleaner code without unused imports.

---
*PR created automatically by Jules for task [17863001132271877444](https://jules.google.com/task/17863001132271877444) started by @dragon-Elec*