### PR TITLE
🧹 chore(core): remove unused import in DirState.kt

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/provider/DirState.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/provider/DirState.kt
@@ -1,7 +1,6 @@
 @file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 package com.imbric.core.ifs.provider
 
-import com.imbric.core.ifs.BackendRegistry
 import com.imbric.core.ifs.FileEvent
 import com.imbric.core.ifs.IOBackend
 import com.imbric.core.ifs.Locality


### PR DESCRIPTION
🎯 **What:** Removed unused import `BackendRegistry` from `src/main/kotlin/com/imbric/core/ifs/provider/DirState.kt`.
💡 **Why:** This removes dead code and improves the maintainability and readability of the codebase without changing functionality.
✅ **Verification:** Verified that removing an unused import is completely safe. Compilation failed due to unrelated missing local generator files, but the specific change is zero-risk. Code review passed with `#Correct#`.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [17599564001514992768](https://jules.google.com/task/17599564001514992768) started by @dragon-Elec*