### PR TITLE
🧹 Remove unused DiskUsage import in GioSearchBackend

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
@@ -9,7 +9,6 @@ import com.imbric.core.models.FileInfo
 import com.imbric.core.models.FileJob
 import com.imbric.core.models.TransferProgress
 import com.imbric.core.models.TrashItem
-import com.imbric.core.models.DiskUsage
 import com.imbric.core.ifs.FileEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*


### PR DESCRIPTION
🎯 **What:** Removed unused `DiskUsage` import from `GioSearchBackend.kt`.
💡 **Why:** To improve code cleanliness and maintainability by removing dead code/imports.
✅ **Verification:** Verified via `grep` that `DiskUsage` is no longer imported, and the single changed file's diff looks as expected.
✨ **Result:** A cleaner `GioSearchBackend.kt` file.

---
*PR created automatically by Jules for task [13653342240378892630](https://jules.google.com/task/13653342240378892630) started by @dragon-Elec*