### PR TITLE
🧹 Remove unused import in TransferOrchestrator

### DIFF
--- a/src/main/kotlin/com/imbric/core/transactions/TransferOrchestrator.kt
+++ b/src/main/kotlin/com/imbric/core/transactions/TransferOrchestrator.kt
@@ -3,7 +3,6 @@ package com.imbric.core.transactions
 
 import com.imbric.core.ifs.*
 import com.imbric.core.logic.*
-import com.imbric.core.models.FileInfo
 import com.imbric.core.transactions.models.TransactionEvent
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*


### PR DESCRIPTION
🎯 **What:** Removed unused import `com.imbric.core.models.FileInfo` from `TransferOrchestrator.kt`.
💡 **Why:** This improves maintainability and code cleanliness by removing an unused dependency in the file, keeping the codebase tidy.
✅ **Verification:** Verified the code health issue was resolved. The unused import is gone and there is no behavioral change.
✨ **Result:** Improved readability and maintainability.

---
*PR created automatically by Jules for task [2692525941339646443](https://jules.google.com/task/2692525941339646443) started by @dragon-Elec*