### PR TITLE
🧪 test: add initialization test for ImbricDesktop

### DIFF
--- a/src/test/kotlin/com/imbric/core/desktop/ImbricDesktopTest.kt
+++ b/src/test/kotlin/com/imbric/core/desktop/ImbricDesktopTest.kt
@@ -1,0 +1,31 @@
+package com.imbric.core.desktop
+
+import com.imbric.core.ifs.BackendRegistry
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ImbricDesktopTest {
+    @Test
+    fun testInitializeRegistersExpectedSchemes() {
+        ImbricDesktop.initialize()
+
+        // Verify that the schemes were registered correctly.
+        // Even though getRegisteredSchemes() exists, we can also verify by fetching them.
+        assertNotNull(BackendRegistry.getIo("file://"))
+        assertNotNull(BackendRegistry.getIo("trash://"))
+        assertNotNull(BackendRegistry.getIo("smb://"))
+        assertNotNull(BackendRegistry.getIo("sftp://"))
+        assertNotNull(BackendRegistry.getIo("recent://"))
+        assertNotNull(BackendRegistry.getIo("search://"))
+
+        // Also verify with getRegisteredSchemes if we want
+        val registeredSchemes = BackendRegistry.getRegisteredSchemes()
+        assertTrue(registeredSchemes.contains("file"))
+        assertTrue(registeredSchemes.contains("trash"))
+        assertTrue(registeredSchemes.contains("smb"))
+        assertTrue(registeredSchemes.contains("sftp"))
+        assertTrue(registeredSchemes.contains("recent"))
+        assertTrue(registeredSchemes.contains("search"))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing initialization test for `ImbricDesktop`.
📊 **Coverage:** Tests that `ImbricDesktop.initialize()` correctly populates `BackendRegistry` with the expected schemes (`file`, `trash`, `smb`, `sftp`, `recent`, `search`).
✨ **Result:** Improved test coverage verifying the initialization state and backend scheme routing.

---
*PR created automatically by Jules for task [18100171987645985746](https://jules.google.com/task/18100171987645985746) started by @dragon-Elec*