### PR TITLE
🧹 Remove unused Uuid imports from GioRecentBackend

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioRecentBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioRecentBackend.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package com.imbric.core.ifs.backends
 
 import com.imbric.core.ifs.*
@@ -12,8 +11,6 @@ import org.gnome.gtk.Gtk
 import org.gnome.gtk.RecentManager
 import org.gnome.gio.File
 import org.gnome.gio.FileQueryInfoFlags
-import kotlin.uuid.Uuid
-import kotlin.uuid.ExperimentalUuidApi
 
 class GioRecentBackend : IOBackend {
     init {


### PR DESCRIPTION
🎯 **What:** Removed unused Uuid imports from `src/main/kotlin/com/imbric/core/ifs/backends/GioRecentBackend.kt`.

💡 **Why:** `Uuid` was no longer being used in this file, so the imports `kotlin.uuid.Uuid` and `kotlin.uuid.ExperimentalUuidApi`, as well as the file-level `@file:OptIn(ExperimentalUuidApi::class)` annotation, were cluttering the code and reducing readability.

✅ **Verification:** Verified via tests and manual inspection (`grep`) that the removal does not cause issues and that the import was indeed unused. Code review passed successfully.

✨ **Result:** A cleaner, more maintainable code file with no unnecessary imports.

---
*PR created automatically by Jules for task [5071693742457384985](https://jules.google.com/task/5071693742457384985) started by @dragon-Elec*