### PR TITLE
🧹 Replace System.err.println with logger in Main.kt

### DIFF
--- a/src/main/kotlin/com/imbric/app/bootstrap/Main.kt
+++ b/src/main/kotlin/com/imbric/app/bootstrap/Main.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.window.application
 import org.gnome.gio.Application
 import org.gnome.gio.ApplicationFlags
 import org.gnome.gio.Gio
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Entry point for ImbricFS Desktop.
@@ -29,7 +32,7 @@ fun main(args: Array<String>) {
         app.register(null)
     } catch (e: Exception) {
         // Fallback: Continue anyway, though some native events might not work.
-        System.err.println("Warning: Could not register GApplication: ${e.message}")
+        logger.warn(e) { "Could not register GApplication: ${e.message}" }
     }
 
     // 3. Launch Compose UI


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was using `System.err.println` to log a warning when registering `GApplication` failed in `Main.kt`. This was replaced with a proper logger call using `mu.KotlinLogging`.
💡 **Why:** How this improves maintainability: It enables proper log filtering, formatting, and routing of messages. It also captures the exception details correctly for better debugging.
✅ **Verification:** How you confirmed the change is safe: Verified through manual code review that the logger accurately captures the exception and message without changing application logic. Compilation wasn't possible due to an environment-specific native binding issue with the java-gi project locally path.
✨ **Result:** The improvement achieved: Removed a hardcoded `System.err.println` that could clutter standard output, improving logging hygiene.

---
*PR created automatically by Jules for task [2725614875331661732](https://jules.google.com/task/2725614875331661732) started by @dragon-Elec*