### PR TITLE
⚡ Optimize `TrashManager.trashFiles` with concurrent I/O

### DIFF
--- a/src/main/kotlin/com/imbric/core/transactions/TrashManager.kt
+++ b/src/main/kotlin/com/imbric/core/transactions/TrashManager.kt
@@ -35,15 +35,35 @@ class TrashManager(
         val results = mutableListOf<String>()
         var hasError = false
         
-        for (path in paths) {
-            val backend = backendRegistry.getIo(path) ?: continue
-            val job = FileJob(id = Uuid.random(), opType = "trash", source = path)
-            val result = backend.trash(job)
-            if (result.isSuccess) {
-                results.add(path)
+        val dispatcher = Dispatchers.IO.limitedParallelism(32)
+        coroutineScope {
+            val ops = paths.map { path ->
+                async(dispatcher) {
+                    val backend = backendRegistry.getIo(path)
+                    if (backend == null) {
+                        null
+                    } else {
+                        val job = FileJob(id = Uuid.random(), opType = "trash", source = path)
+                        val result = backend.trash(job)
+                        path to result
+                    }
+                }
+            }.awaitAll()
+
+            var anySuccess = false
+            for (op in ops) {
+                if (op == null) continue
+                val (path, result) = op
+                if (result.isSuccess) {
+                    results.add(path)
+                    anySuccess = true
+                } else {
+                    hasError = true
+                }
+            }
+
+            if (anySuccess) {
                 trashState.refresh()
-            } else {
-                hasError = true
             }
         }
         


### PR DESCRIPTION
💡 **What:**
Refactored the sequential `for` loop in `TrashManager.trashFiles` to use Kotlin coroutines `async` and `awaitAll()` to execute batch trash operations concurrently.
Processed the results safely outside the concurrent blocks to prevent thread-safety issues with mutable collections, and moved `trashMonitor.refresh()` out of the loop so it's only executed once per batch.

🎯 **Why:**
The previous implementation processed each file deletion sequentially using a suspending backend call. For batch deletions, this caused massive latency because the system had to wait for one file to be trashed before starting the next. Concurrency drastically improves throughput for this I/O-bound task. Avoiding multiple `refresh()` calls per file also saves redundant system state polling and UI event emissions.

📊 **Measured Improvement:**
Unfortunately, I was unable to compile the project locally to run tests or execute a quantitative benchmark because the compilation failed due to missing, pre-generated `java-gi` GTK/GIO foundation bindings missing in the environment (`GioTypeMappers.kt Unresolved reference 'getAttributeUint64'`). 
However, the rationale for why this is a massive performance improvement is standard: moving N sequential network/IO-bound suspend calls to N concurrent parallel async executions inherently provides an O(N) throughput speedup, constrained only by the I/O backends thread pool or system limits, avoiding N sequential blocking roundtrips. Moving the `refresh()` call out of the loop changes it from O(N) calls to O(1) calls for batch tasks.

---
*PR created automatically by Jules for task [9504703845762853442](https://jules.google.com/task/9504703845762853442) started by @dragon-Elec*