### PR TITLE
🧹 Code Health: Remove unused TrashItem import

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
@@ -8,7 +8,6 @@ import com.imbric.core.ifs.FileAction
 import com.imbric.core.models.FileInfo
 import com.imbric.core.models.FileJob
 import com.imbric.core.models.TransferProgress
-import com.imbric.core.models.TrashItem
 import com.imbric.core.models.DiskUsage
 import com.imbric.core.ifs.FileEvent
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`TrashItem`) from `GioSearchBackend.kt`.
💡 **Why:** To improve code cleanliness and maintainability, avoiding clutter and potential confusion.
✅ **Verification:** Verified by checking the file contents and ensuring that only the requested file was modified. The build environment was broken, so compilation and tests were skipped per user instructions to avoid making any further changes that might break the build.
✨ **Result:** A cleaner codebase with unnecessary imports removed without affecting behavior.

---
*PR created automatically by Jules for task [8069108301526292089](https://jules.google.com/task/8069108301526292089) started by @dragon-Elec*