### PR TITLE
🧹 Refactor TransferOrchestrator conflict resolution logic

### DIFF
--- a/src/main/kotlin/com/imbric/core/transactions/TransferOrchestrator.kt
+++ b/src/main/kotlin/com/imbric/core/transactions/TransferOrchestrator.kt
@@ -61,25 +61,7 @@ class TransferOrchestrator(
         }
         
         val jitResolver: suspend (ConflictContext) -> ConflictResponse = { context ->
-            val existing = mutex.withLock { stickyDecisions[context.type] }
-            if (existing != null) {
-                ConflictResponse(existing)
-            } else {
-                val response = onManualConflict(context)
-                if (response.applyToAll) {
-                    mutex.withLock {
-                        val doubleCheck = stickyDecisions[context.type]
-                        if (doubleCheck == null) {
-                            stickyDecisions[context.type] = response.action
-                            response
-                        } else {
-                            ConflictResponse(doubleCheck)
-                        }
-                    }
-                } else {
-                    response
-                }
-            }
+            getOrPromptDecision(context, onManualConflict, stickyDecisions, mutex)
         }
 
         transactionManager.commitTransaction(tid, jitResolver, policy)
@@ -124,25 +106,8 @@ class TransferOrchestrator(
         }
         
         if (action is ConflictAction.Prompt) {
-            val existing = mutex.withLock { stickyDecisions[conflictType] }
-            val response = if (existing != null) {
-                ConflictResponse(existing)
-            } else {
-                val res = onManualConflict(ConflictContext(src, dest, srcMeta, destMeta, conflictType))
-                if (res.applyToAll) {
-                    mutex.withLock {
-                        val doubleCheck = stickyDecisions[conflictType]
-                        if (doubleCheck == null) {
-                            stickyDecisions[conflictType] = res.action
-                            res
-                        } else {
-                            ConflictResponse(doubleCheck)
-                        }
-                    }
-                } else {
-                    res
-                }
-            }
+            val context = ConflictContext(src, dest, srcMeta, destMeta, conflictType)
+            val response = getOrPromptDecision(context, onManualConflict, stickyDecisions, mutex)
             action = response.action
         }
         
@@ -167,5 +132,31 @@ class TransferOrchestrator(
         }
     }
     
+    private suspend fun getOrPromptDecision(
+        context: ConflictContext,
+        onManualConflict: suspend (ConflictContext) -> ConflictResponse,
+        stickyDecisions: MutableMap<ConflictType, ConflictAction>,
+        mutex: Mutex
+    ): ConflictResponse {
+        val existing = mutex.withLock { stickyDecisions[context.type] }
+        if (existing != null) {
+            return ConflictResponse(existing)
+        }
+
+        val response = onManualConflict(context)
+        if (response.applyToAll) {
+            return mutex.withLock {
+                val doubleCheck = stickyDecisions[context.type]
+                if (doubleCheck == null) {
+                    stickyDecisions[context.type] = response.action
+                    response
+                } else {
+                    ConflictResponse(doubleCheck)
+                }
+            }
+        }
+        return response
+    }
+
     private data class ValidatedOp(val src: String, val dest: String, val overwrite: Boolean, val autoRename: Boolean = false)
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `planOperation` function in `TransferOrchestrator.kt` was reported as being too long and complex. It also duplicated the exact double-checked locking concurrency logic used earlier in the file to resolve conflict actions.

💡 **Why:** How this improves maintainability
Extracting this complex locking and prompting logic into a dedicated helper function (`getOrPromptDecision`) makes `planOperation` much easier to read and understand at a glance. It also centralizes the conflict resolution state updates, ensuring that if the logic needs to change in the future, it only needs to be updated in one place.

✅ **Verification:** How you confirmed the change is safe
The change preserves the exact same locking and execution flow as the original inline code. The refactoring was purely structural and the code review process confirmed the approach as `#Correct#`.

✨ **Result:** The improvement achieved
A significantly shorter, cleaner `planOperation` function and a DRY codebase without duplicate synchronization blocks.

---
*PR created automatically by Jules for task [14991690390116505375](https://jules.google.com/task/14991690390116505375) started by @dragon-Elec*