### PR TITLE
🧹 Remove unused Uuid imports from GioBackend.kt

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package com.imbric.core.ifs.backends
 
 import com.imbric.core.ifs.*
@@ -11,7 +10,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
-import kotlin.uuid.Uuid
 import org.gnome.gio.File
 import org.gnome.gio.FileQueryInfoFlags
 import org.gnome.gio.FileType
@@ -21,7 +19,6 @@ import org.gnome.gio.FileMonitorEvent
 import org.gnome.gio.FileCreateFlags
 import org.gnome.gio.FileProgressCallback
 import org.gnome.glib.GLib
-import kotlin.uuid.ExperimentalUuidApi
 import org.gnome.gdkpixbuf.GdkPixbuf
 import org.gnome.gdkpixbuf.PixbufLoader
 import org.gnome.glib.KeyFile


### PR DESCRIPTION
🎯 **What:** Removed unused `Uuid` imports and the `@file:OptIn(ExperimentalUuidApi::class)` annotation from `src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt`.

💡 **Why:** To improve the maintainability and readability of the codebase by keeping imports clean.

✅ **Verification:** Verified the removal of unused imports visually and via `git diff`. The sandbox environment does not meet the project's build requirements to run tests locally, but removing unused imports is a safe, zero-risk operation that improves code cleanliness. Code review was requested and approved.

✨ **Result:** Improved code cleanliness and readability.

---
*PR created automatically by Jules for task [5886038290618574264](https://jules.google.com/task/5886038290618574264) started by @dragon-Elec*