### PR TITLE
🧹 code health: remove unused Uuid import from GioBackend.kt

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
 package com.imbric.core.ifs.backends
 
 import com.imbric.core.ifs.*
@@ -11,7 +10,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
-import kotlin.uuid.Uuid
 import org.gnome.gio.File
 import org.gnome.gio.FileQueryInfoFlags
 import org.gnome.gio.FileType
@@ -21,7 +19,6 @@ import org.gnome.gio.FileMonitorEvent
 import org.gnome.gio.FileCreateFlags
 import org.gnome.gio.FileProgressCallback
 import org.gnome.glib.GLib
-import kotlin.uuid.ExperimentalUuidApi
 import org.gnome.gdkpixbuf.GdkPixbuf
 import org.gnome.gdkpixbuf.PixbufLoader
 import org.gnome.glib.KeyFile


### PR DESCRIPTION
🎯 **What:** Removed unused `kotlin.uuid.Uuid` and `kotlin.uuid.ExperimentalUuidApi` imports and the `@file:OptIn(ExperimentalUuidApi::class)` annotation from `src/main/kotlin/com/imbric/core/ifs/backends/GioBackend.kt`.

💡 **Why:** To improve code maintainability and readability by cleaning up unnecessary and dead code imports.

✅ **Verification:** Since the sandbox environment lacked the required build dependencies (JDK 25 and GNOME GIR files), the change was manually verified via visual code review and successfully passed the agentic code review tool with a correct rating. 

✨ **Result:** A cleaner `GioBackend.kt` file with no lingering unused dependencies.

---
*PR created automatically by Jules for task [14573994249570981862](https://jules.google.com/task/14573994249570981862) started by @dragon-Elec*