### PR TITLE
🧪 [Test] Verify search fallback in GioSearchBackend

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioSearchBackend.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.*
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
-class GioSearchBackend(private val fallback: GioBackend = GioBackend()) : IOBackend {
+open class GioSearchBackend(private val fallback: IOBackend = GioBackend()) : IOBackend {
     override val scheme: String = "search"
     override val displayName: String = "GNOME Tracker Search"
 
@@ -55,7 +55,9 @@ class GioSearchBackend(private val fallback: GioBackend = GioBackend()) : IOBack
         var scanned = 0
         
         try {
-            runTrackerSearch(query).collect { uri ->
+            // runTrackerSearch might throw immediately, or might throw during collection
+            val trackerFlow = runTrackerSearch(query)
+            trackerFlow.collect { uri ->
                 scanned++
                 if (scanned % 100 == 0) {
                     query.onScanned?.invoke(scanned)
@@ -89,7 +91,8 @@ class GioSearchBackend(private val fallback: GioBackend = GioBackend()) : IOBack
         }
     }.flowOn(Dispatchers.IO)
 
-    private fun runTrackerSearch(query: com.imbric.core.models.VfsQuery): Flow<String> = flow {
+    // Visible for testing
+    internal open fun runTrackerSearch(query: com.imbric.core.models.VfsQuery): Flow<String> = flow {
         val flag = if (query.contentSearch) "-c" else "-f"
         val process = ProcessBuilder("tracker3", "search", "--disable-color", flag, "--", query.text)
             .start()

--- a/src/test/kotlin/com/imbric/core/ifs/backends/GioSearchBackendTest.kt
+++ b/src/test/kotlin/com/imbric/core/ifs/backends/GioSearchBackendTest.kt
@@ -1,0 +1,73 @@
+package com.imbric.core.ifs.backends
+
+import com.imbric.core.ifs.BackendCapabilities
+import com.imbric.core.ifs.FileAction
+import com.imbric.core.ifs.IOBackend
+import com.imbric.core.ifs.LatencyProfile
+import com.imbric.core.ifs.Locality
+import com.imbric.core.models.FileInfo
+import com.imbric.core.models.FileJob
+import com.imbric.core.models.TransferProgress
+import com.imbric.core.models.VfsQuery
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class GioSearchBackendTest {
+
+    class MockFallbackBackend(private val mockResults: List<FileInfo>) : IOBackend {
+        override val scheme: String = "mock"
+        override val displayName: String = "Mock Backend"
+
+        var searchCalled = false
+            private set
+
+        override suspend fun canPerform(action: FileAction, uri: String): Boolean = true
+        override fun list(uri: String): Flow<FileInfo> = flowOf()
+        override suspend fun getMetadata(uri: String): Result<FileInfo> = Result.failure(Exception("Not implemented"))
+        override fun exists(uri: String): Boolean = false
+        override suspend fun readHeader(uri: String, size: Long): Result<ByteArray> = Result.failure(Exception("Not implemented"))
+        override suspend fun copy(job: FileJob): Flow<TransferProgress> = flowOf()
+        override suspend fun move(job: FileJob): Flow<TransferProgress> = flowOf()
+        override suspend fun trash(job: FileJob, recoverTrashUri: Boolean): Result<String> = Result.failure(Exception("Not implemented"))
+        override suspend fun restoreFromTrash(trashPath: String, originalPath: String): Result<String> = Result.failure(Exception("Not implemented"))
+        override suspend fun delete(job: FileJob): Result<Unit> = Result.failure(Exception("Not implemented"))
+        override suspend fun createFolder(parentUri: String, name: String): Result<String> = Result.failure(Exception("Not implemented"))
+        override suspend fun createFile(parentUri: String, name: String): Result<String> = Result.failure(Exception("Not implemented"))
+        override suspend fun rename(uri: String, newName: String): Result<String> = Result.failure(Exception("Not implemented"))
+
+        override fun search(query: VfsQuery): Flow<FileInfo> {
+            searchCalled = true
+            return flowOf(*mockResults.toTypedArray())
+        }
+    }
+
+    @Test
+    fun testFallbackIsCalledWhenTrackerFails() = runTest {
+        val mockFileInfo = FileInfo(
+            uri = "file:///tmp/test.txt",
+            name = "test.txt",
+            size = 123L,
+            isDirectory = false,
+            mimeType = "text/plain"
+        )
+        val mockFallback = MockFallbackBackend(listOf(mockFileInfo))
+        val searchBackend = object : GioSearchBackend(fallback = mockFallback) {
+            override fun runTrackerSearch(query: VfsQuery): Flow<String> {
+                throw Exception("Simulated Tracker failure")
+            }
+        }
+
+        val query = VfsQuery(text = "test", rootUri = "file:///tmp")
+
+        val results = searchBackend.search(query).toList()
+
+        assertEquals(1, results.size)
+        assertEquals("test.txt", results[0].name)
+        assertEquals(true, mockFallback.searchCalled, "Fallback backend should have been called")
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `GioSearchBackend` where the fallback to `GioBackend` manual search was untested.
📊 **Coverage:** The scenario where the `tracker3` process fails and throws an exception is now covered by testing that the fallback backend's `search` method is invoked.
✨ **Result:** Improved test coverage and verification of the fallback logic reliability.

---
*PR created automatically by Jules for task [13145592201045783415](https://jules.google.com/task/13145592201045783415) started by @dragon-Elec*