### PR TITLE
🧪 testing improvement for GioRecentBackend unsupported operations

### DIFF
--- a/src/test/kotlin/com/imbric/core/desktop/backends/GioRecentBackendTest.kt
+++ b/src/test/kotlin/com/imbric/core/desktop/backends/GioRecentBackendTest.kt
@@ -15,4 +15,50 @@ class GioRecentBackendTest {
         // Note: size might be 0 if the user has no recent items, but it shouldn't crash.
         assertTrue(items != null)
     }
+
+    @Test
+    fun testUnsupportedOperations() = runBlocking {
+        val backend = GioRecentBackend()
+        val dummyJob = com.imbric.core.models.FileJob(
+            opType = "test",
+            source = "recent:///dummy",
+            dest = "recent:///dummy2"
+        )
+
+        val metadataResult = backend.getMetadata("recent:///dummy")
+        assertTrue(metadataResult.isFailure)
+        assertTrue(metadataResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val readHeaderResult = backend.readHeader("recent:///dummy", 1024)
+        assertTrue(readHeaderResult.isFailure)
+        assertTrue(readHeaderResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val trashResult = backend.trash(dummyJob, false)
+        assertTrue(trashResult.isFailure)
+        assertTrue(trashResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val restoreResult = backend.restoreFromTrash("recent:///dummy", "recent:///dummy")
+        assertTrue(restoreResult.isFailure)
+        assertTrue(restoreResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val deleteResult = backend.delete(dummyJob)
+        assertTrue(deleteResult.isFailure)
+        assertTrue(deleteResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val createFolderResult = backend.createFolder("recent:///", "newFolder")
+        assertTrue(createFolderResult.isFailure)
+        assertTrue(createFolderResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val createFileResult = backend.createFile("recent:///", "newFile")
+        assertTrue(createFileResult.isFailure)
+        assertTrue(createFileResult.exceptionOrNull() is UnsupportedOperationException)
+
+        val renameResult = backend.rename("recent:///dummy", "newName")
+        assertTrue(renameResult.isFailure)
+        assertTrue(renameResult.exceptionOrNull() is UnsupportedOperationException)
+
+        // empty flows for copy and move
+        assertTrue(backend.copy(dummyJob).toList().isEmpty())
+        assertTrue(backend.move(dummyJob).toList().isEmpty())
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added tests to cover the unsupported file operations in `GioRecentBackend`. These methods explicitly return a `Result.failure(UnsupportedOperationException)` or empty flows since recent files handles lists natively but does not support mutating operations directly.

📊 **Coverage:** The `testUnsupportedOperations` unit test covers `getMetadata`, `readHeader`, `trash`, `restoreFromTrash`, `delete`, `createFolder`, `createFile`, `rename`, `copy`, and `move`. The assertions properly check for `isFailure` and the specific `UnsupportedOperationException` class, per the Kotlin Result pattern in the codebase.

✨ **Result:** Improved test coverage and reliability verifying that invoking mutating/unsupported operations fails as expected on the virtual `recent:///` backend.

---
*PR created automatically by Jules for task [10687280184246979827](https://jules.google.com/task/10687280184246979827) started by @dragon-Elec*