### PR TITLE
🧹 code health: refactor `toImbricFileInfo` in GioTypeMappers

### DIFF
--- a/src/main/kotlin/com/imbric/core/ifs/backends/GioTypeMappers.kt
+++ b/src/main/kotlin/com/imbric/core/ifs/backends/GioTypeMappers.kt
@@ -21,29 +21,27 @@ object GioTypeMappers {
     ): FileInfo {
         val uri = gfile.uri?.toString() ?: ""
         val name = gioInfo.name?.toString() ?: ""
-        val pathType = determinePathType(uri)
-        val nativeId = getNativeId(gioInfo)
         
         return FileInfo(
-            nativeId = nativeId,
+            nativeId = getNativeId(gioInfo),
             name = name,
             path = gfile.path?.toString() ?: uri,
             uri = uri,
-            pathType = pathType,
+            pathType = determinePathType(uri),
             displayName = gioInfo.displayName?.toString() ?: name,
             isDirectory = gioInfo.fileType == org.gnome.gio.FileType.DIRECTORY,
             isSymlink = gioInfo.isSymlink,
-            symlinkTarget = if (gioInfo.isSymlink) gioInfo.symlinkTarget?.toString() else null,
+            symlinkTarget = gioInfo.mappedSymlinkTarget,
             size = gioInfo.size,
-            mimeType = gioInfo.contentType?.toString() ?: "application/octet-stream",
-            modifiedTime = gioInfo.modificationDateTime?.let { Instant.fromEpochSeconds(it.toUnix()) },
+            mimeType = gioInfo.mappedMimeType,
+            modifiedTime = gioInfo.mappedModifiedTime,
             accessedTime = getTimestamp(gioInfo, "time::access"),
             createdTime = getTimestamp(gioInfo, "time::created"),
             isHidden = gioInfo.isHidden,
             isReadable = gioInfo.getAttributeBoolean("access::can-read"),
             isWritable = gioInfo.getAttributeBoolean("access::can-write"),
             isExecutable = gioInfo.getAttributeBoolean("access::can-execute"),
-            permissions = gioInfo.getAttributeUint32("unix::mode").takeIf { it > 0 }?.toString(8) ?: "",
+            permissions = gioInfo.mappedPermissions,
             owner = gioInfo.getAttributeString("owner::user") ?: "",
             group = gioInfo.getAttributeString("owner::group") ?: "",
             iconName = getIconName(gioInfo),
@@ -73,6 +71,18 @@ object GioTypeMappers {
             attributes = extractAttributes(gioInfo)
         )
     }
+
+    private val org.gnome.gio.FileInfo.mappedSymlinkTarget: String?
+        get() = if (isSymlink) symlinkTarget?.toString() else null
+
+    private val org.gnome.gio.FileInfo.mappedMimeType: String
+        get() = contentType?.toString() ?: "application/octet-stream"
+
+    private val org.gnome.gio.FileInfo.mappedModifiedTime: Instant?
+        get() = modificationDateTime?.let { Instant.fromEpochSeconds(it.toUnix()) }
+
+    private val org.gnome.gio.FileInfo.mappedPermissions: String
+        get() = getAttributeUint32("unix::mode").takeIf { it > 0 }?.toString(8) ?: ""
 
     private fun extractAttributes(gioInfo: org.gnome.gio.FileInfo): Map<String, Any?> {
         val attributeMap = mutableMapOf<String, Any?>()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored the `toImbricFileInfo` function in `GioTypeMappers.kt` which was flagged as a "Long function" due to its extensive inline field extraction logic.
  
💡 **Why:** How this improves maintainability
The long constructor call made the mapper hard to read and modify. By extracting specific fields into well-named private extension properties on `org.gnome.gio.FileInfo`, we reduce the cognitive load when reading the code, keeping the constructor call concise and making the mapping intent explicitly clear.
  
✅ **Verification:** How you confirmed the change is safe
Ran the integration tests, specifically for `GioTypeMappersIntegrationTest`, `GioRecentBackendTest`, and `GioBackendTest`. `compileKotlin` passes seamlessly. No semantic logic or behavior changes were introduced.

✨ **Result:** The improvement achieved
The `toImbricFileInfo` mapper has improved readability and separates the metadata-extracting logic from the raw data object instantiation.

---
*PR created automatically by Jules for task [7869895734248897182](https://jules.google.com/task/7869895734248897182) started by @dragon-Elec*